### PR TITLE
Bring back MultivariatePolynomials v0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,8 @@ MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-DynamicPolynomials = "0.4"
-MultivariatePolynomials = "0.4"
+DynamicPolynomials = "0.3, 0.4"
+MultivariatePolynomials = "0.3, 0.4"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
I cannot use my registry at the moment because some other package requires the old version:

```julia
(@v1.7) pkg> resolve
ERROR: Unsatisfiable requirements detected for package MultivariatePolynomials [102ac46a]:
 MultivariatePolynomials [102ac46a] log:
 ├─possible versions are: 0.2.0-0.4.2 or uninstalled
 ├─restricted to versions 0.4 by CarlemanLinearization [4803f6b2], leaving only versions 0.4.0-0.4.2
 │ └─CarlemanLinearization [4803f6b2] log:
 │   ├─possible versions are: 0.3.0 or uninstalled
 │   └─CarlemanLinearization [4803f6b2] is fixed to version 0.3.0
 └─restricted to versions 0.3.18 by an explicit requirement — no versions left
```