### PR TITLE
Load IntervalArithmetic directly instead of through LazySets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1.4"
 
 [extras]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
+IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CarlemanLinearization"
 uuid = "4803f6b2-022a-4c1b-a771-522a3413ec86"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"

--- a/src/init.jl
+++ b/src/init.jl
@@ -6,6 +6,8 @@ using MultivariatePolynomials: AbstractVariable, AbstractMonomialLike,
 function __init__()
     @require LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043" begin
         using .LazySets: Hyperrectangle, dim, low, high
-        using .LazySets.IntervalArithmetic: interval
+    end
+    @require IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253" begin
+        using .IntervalArithmetic: interval
     end
 end


### PR DESCRIPTION
Since `LazySets.IntervalArithmetic` is not available anymore, the current `master` fails when loading `LazySets`. The solution here is to load the (optional) dependency directly. Since `LazySets` still loads `IntervalArithmetic`, there is no change in the workflow.