### PR TITLE
Fix and test a-priori error bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.3.4"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+ReachabilityBase = "379f33d0-9447-4353-bd03-d664070e549f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 IterTools = "1"
 MultivariatePolynomials = "0.3, 0.4, 0.5"
+ReachabilityBase = "0.1.8"
 Requires = "0.5, 1"
 julia = "1.4"

--- a/src/error_bounds.jl
+++ b/src/error_bounds.jl
@@ -3,7 +3,7 @@
 #
 # References:
 #
-# - [1] Forets, Marcelo, and Amaury Pouly. "Explicit error bounds for carleman linearization."
+# - [1] Forets, Marcelo, and Amaury Pouly. "Explicit error bounds for Carleman linearization."
 #       arXiv preprint arXiv:1711.02552 (2017).
 #
 # - [2] Liu, J. P., Kolden, H. Ø., Krovi, H. K., Loureiro, N. F., Trivisa, K., & Childs,7
@@ -34,7 +34,7 @@ function convergence_radius_apriori(α, F₁, F₂; N)
     if μF₁ < 0
         return Inf
     end
-    β = α * F₂ / μF₁
+    β = α * nF₂ / μF₁
     T = (1 / μF₁) * log(1 + 1 / β)
     return T
 end

--- a/src/error_bounds.jl
+++ b/src/error_bounds.jl
@@ -27,7 +27,7 @@ function error_bound_apriori(α, F₁, F₂; N)
 end
 
 # See Theorem 4.2 in [1]
-function convergence_radius_apriori(α, F₁, F₂; N)
+function convergence_radius_apriori(α, F₁, F₂)
     nF₂ = opnorm(F₂, Inf)
     μF₁ = logarithmic_norm(F₁, Inf)
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -2,6 +2,7 @@ using IterTools, LinearAlgebra, Requires, SparseArrays
 
 using MultivariatePolynomials: AbstractVariable, AbstractMonomialLike, exponents, variables, powers,
                                monomials, coefficient
+using ReachabilityBase.Arrays: logarithmic_norm
 
 function __init__()
     @require LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,3 +115,22 @@ end
           Set{Tuple{Rational,Rational}}([(0, 1), (1, 2), (-1, 3), (0, 1), (1, 4), (0, 9), (0, 2),
                                          (-1, 3), (-2, 6)])
 end
+
+@testset "Error bounds" begin
+    F1_neg = [-2.0 -1; -1 -2]
+    F1 = [0.0 1; -1 -2]
+    F2 = [0.0 0 0 1; 1 -2.2 0 0]
+    α = 0.1
+
+    T = convergence_radius_apriori(α, F1_neg, F2)
+    @test T == Inf
+
+    T = convergence_radius_apriori(α, F1, F2)
+    @test T ≈ 1.417 atol=1e-4
+
+    e2 = error_bound_apriori(α, F1, F2; N=2)
+    e3 = error_bound_apriori(α, F1, F2; N=3)
+    for t in 0.01:0.01:T
+        @test e3(t) < e2(t)
+    end
+end


### PR DESCRIPTION
These functions were not useable (`logarithmic_norm` not defined), and one of them had a bug and a useless argument.

This PR requires a new release of `ReachabilityBase` (see https://github.com/JuliaReach/ReachabilityBase.jl/pull/39). Here I assumed a new patch release v0.1.8, but it could also be changed to a new minor release v0.2. 